### PR TITLE
test(tfproviderlint): trigger AT001 and R018 rules manually

### DIFF
--- a/huaweicloud/services/acceptance/dli/resource_huaweicloud_dli_elastic_resource_pool_test.go
+++ b/huaweicloud/services/acceptance/dli/resource_huaweicloud_dli_elastic_resource_pool_test.go
@@ -146,7 +146,6 @@ func waitForCUModificationComplete(resName string) resource.TestCheckFunc {
 			if time.Since(startTime) > 15*time.Minute {
 				break
 			}
-			// lintignore:R018
 			time.Sleep(30 * time.Second)
 		}
 		return fmt.Errorf("modification timeout for the CU number")

--- a/huaweicloud/services/acceptance/workspace/resource_huaweicloud_workspace_app_hda_batch_upgrade_test.go
+++ b/huaweicloud/services/acceptance/workspace/resource_huaweicloud_workspace_app_hda_batch_upgrade_test.go
@@ -22,7 +22,6 @@ func TestAccAppHdaBatchUpgrade_basic(t *testing.T) {
 		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		// This resource is a one-time action resource and there is no logic in the delete method.
-		// lintignore:AT001
 		CheckDestroy: nil,
 		Steps: []resource.TestStep{
 			{

--- a/huaweicloud/services/acceptance/workspace/resource_huaweicloud_workspace_app_image_server_test.go
+++ b/huaweicloud/services/acceptance/workspace/resource_huaweicloud_workspace_app_image_server_test.go
@@ -49,7 +49,6 @@ func TestAccResourceAppImageServer_basic(t *testing.T) {
 			acceptance.TestAccPreCheckWorkspaceAppImageSpecCode(t)
 		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
-		CheckDestroy:      rc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
 				Config: testResourceAppImageServer_basic(name, name, "Created by script"),


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [ ] Tests added/passed.

```
make testacc TEST='./huaweicloud' TESTARGS='-run=TestAccSomethingV0_basic'
...
=== RUN   TestAccSomethingV0_basic
--- PASS: TestAccSomethingV0_basic (70.75s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       70.796s
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
